### PR TITLE
Fix for crash when using Node.js v9

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,7 @@
     "passport": "^0.3.2",
     "passport-http": "^0.3.0",
     "passport-http-bearer": "^1.0.1",
-    "rand-token": "^0.2.1",
+    "rand-token": "^0.4.0",
     "rc": "1.0.1",
     "sails": "~0.12.9",
     "sails-disk": "~0.10.9",


### PR DESCRIPTION
The app is crashing when calling the `login` action on `UsersAuthController`, due to an undocumented change in Node.js v9 that breaks `rand-token`, but it was fixed on version `0.4.0`. I am using Node.js `9.5.0` and I can confirm crash is now gone after this update.

Error output was:
```
internal/crypto/random.js:44
    throw new errors.TypeError('ERR_INVALID_CALLBACK');
    ^

TypeError [ERR_INVALID_CALLBACK]: Callback must be a function
    at Object.randomBytes (internal/crypto/random.js:44:11)
    at Object.options.source (/Users/jp/spare/react-native-authentication/server/node_modules/rand-token/index.js:60:25)
    at Object.generate (/Users/jp/spare/react-native-authentication/server/node_modules/rand-token/index.js:95:29)
    at child.findOrAdd (/Users/jp/spare/react-native-authentication/server/api/models/Tokens.js:31:21)
    at child.wrapper [as findOrAdd] (/Users/jp/spare/react-native-authentication/server/node_modules/lodash/index.js:3095:19)
    at passport.authenticate (/Users/jp/spare/react-native-authentication/server/api/controllers/UsersAuthController.js:36:18)
    at BasicStrategy.strategy.success (/Users/jp/spare/react-native-authentication/server/node_modules/passport/lib/middleware/authenticate.js:201:18)
    at verified (/Users/jp/spare/react-native-authentication/server/node_modules/passport-http/lib/passport-http/strategies/basic.js:91:10)
    at bcrypt.compare (/Users/jp/spare/react-native-authentication/server/config/passport.js:48:13)
```

More info: https://github.com/sehrope/node-rand-token/issues/9

Cheers and thank you for your post! https://medium.com/@alexmngn/the-essential-boilerplate-to-authenticate-users-on-your-react-native-app-f7a8e0e04a42 👍🏻 🍻